### PR TITLE
Add cmake3 preferring mechanism

### DIFF
--- a/cmetrics-ruby.gemspec
+++ b/cmetrics-ruby.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-compiler", "~> 1.0"
   spec.add_development_dependency "rake-compiler-dock", "~> 1.0"
 
-  spec.add_dependency 'mini_portile2', '~> 2.1'
+  spec.add_dependency 'mini_portile2', '~> 2.7'
 end

--- a/ext/cmetrics/cmetrics_serde.c
+++ b/ext/cmetrics/cmetrics_serde.c
@@ -135,13 +135,14 @@ rb_cmetrics_serde_from_msgpack_feed_each_impl(VALUE self, VALUE rb_msgpack_buffe
     struct CMetricsSerde* cmetricsSerde;
     struct cmt *cmt = NULL;
     int ret = 0;
+    size_t offset = 0;
 
     RETURN_ENUMERATOR(self, 0, 0);
 
     TypedData_Get_Struct(
             self, struct CMetricsSerde, &rb_cmetrics_serde_type, cmetricsSerde);
 
-    for (size_t offset = 0; offset <= msgpack_length; ) {
+    for (offset = 0; offset <= msgpack_length; ) {
         ret = cmt_decode_msgpack_create(&cmt, StringValuePtr(rb_msgpack_buffer), msgpack_length, &offset);
         if (ret == 0) {
             cmetricsSerde->instance = cmt;


### PR DESCRIPTION
`mini_portile2` starts to support keyword arguments to specify cmake3 or cmake command.
In CentOS7, RHEL7, and Amazon Linux 2 environments, we should use cmake 3.x as `cmake3` via this feature.