### PR TITLE
Add apt and yum linux platforms testing workflows

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -1,0 +1,39 @@
+name: Apt based Linux
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        label:
+          - Debian GNU/Linux Bullseye amd64
+          - Debian GNU/Linux Buster amd64
+          - Ubuntu Bionic amd64
+          - Ubuntu Focal amd64
+        include:
+          - label: Debian GNU/Linux Bullseye amd64
+            test-docker-image: debian:bullseye
+            test-script: ci/apt-test.sh
+          - label: Debian GNU/Linux Buster amd64
+            test-docker-image: debian:buster
+            test-script: ci/apt-test.sh
+          - label: Ubuntu Bionic amd64
+            test-docker-image: ubuntu:bionic
+            test-script: ci/apt-test.sh
+          - label: Ubuntu Focal amd64
+            test-docker-image: ubuntu:focal
+            test-script: ci/apt-test.sh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: rake compile & rake test
+        run: |
+          docker run \
+          --rm \
+          --tty \
+          --volume ${PWD}:/cmetrics-ruby \
+          ${{ matrix.test-docker-image }} \
+          /cmetrics-ruby/${{ matrix.test-script }}

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -1,0 +1,39 @@
+name: Yum based Linux
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        label:
+          - CentOS 7 x86_64
+          - CentOS 8 x86_64
+          - Fedora 34 x86_64
+          - AmazonLinux 2 x86_64
+        include:
+          - label: CentOS 7 x86_64
+            test-docker-image: centos:7
+            test-script: ci/yum-test.sh
+          - label: CentOS 8 x86_64
+            test-docker-image: centos:8
+            test-script: ci/yum-test.sh
+          - label: Fedora 34 x86_64
+            test-docker-image: fedora:34
+            test-script: ci/yum-test.sh
+          - label: AmazonLinux 2 x86_64
+            test-docker-image: amazonlinux:2
+            test-script: ci/yum-test.sh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: rake compile & rake test
+        run: |
+          docker run \
+          --rm \
+          --tty \
+          --volume ${PWD}:/cmetrics-ruby \
+          ${{ matrix.test-docker-image }} \
+          /cmetrics-ruby/${{ matrix.test-script }}

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,10 @@ gemspec
 
 gem "rake", "~> 13.0"
 
-gem "test-unit", "~> 3.0"
+gem "test-unit", "~> 3.4"
+
+local_gemfile = File.join(File.dirname(__FILE__), "Gemfile.local")
+if File.exist?(local_gemfile)
+  puts "Loading Gemfile.local ..." if $DEBUG # `ruby -d` or `bundle -v`
+  instance_eval File.read(local_gemfile)
+end

--- a/ci/apt-test.sh
+++ b/ci/apt-test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -exu
+
+export DEBIAN_FRONTEND=noninteractive
+
+if [ -f /etc/lsb-release ]; then
+    . /etc/lsb-release
+    distribution=$DISTRIB_ID
+    version=${DISTRIB_RELEASE%%.*}
+    codename=${DISTRIB_CODENAME%%.*}
+else
+    distribution="Debian"
+    version=$(cat /etc/debian_version | cut -d'.' -f1)
+fi
+
+apt update
+
+case "$distribution" in
+    "Ubuntu")
+        case "$codename" in
+            "bionic")
+                apt install -V -y wget gpg
+                wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+                echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
+                apt update
+                ;;
+            *)
+                ;;
+        esac
+        ;;
+esac
+
+apt install -V -y lsb-release
+
+apt install -V -y ruby-dev git build-essential pkg-config cmake
+cd /cmetrics-ruby && \
+    gem install bundler --no-document && \
+    bundle install && \
+    bundle exec rake

--- a/ci/yum-test.sh
+++ b/ci/yum-test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -exu
+
+USE_SCL=0
+USE_AMZN_EXT=0
+
+distribution=$(cat /etc/system-release-cpe | awk '{print substr($0, index($1, "o"))}' | cut -d: -f2)
+version=$(cat /etc/system-release-cpe | awk '{print substr($0, index($1, "o"))}' | cut -d: -f4)
+USE_SCL=0
+USE_AMZN_EXT=0
+
+case ${distribution} in
+  amazon)
+    case ${version} in
+      2)
+        DNF=yum
+        USE_AMZN_EXT=1
+        ;;
+    esac
+    ;;
+  centos)
+    case ${version} in
+      7)
+        DNF=yum
+        USE_SCL=1
+        ;;
+      *)
+        DNF="dnf --enablerepo=powertools"
+        ;;
+    esac
+    ;;
+  fedoraproject)
+    case ${version} in
+      33|34)
+        DNF=yum
+        ;;
+    esac
+    ;;
+esac
+
+${DNF} groupinstall -y "Development Tools"
+
+if [ $USE_SCL -eq 1 ]; then
+    ${DNF} install -y centos-release-scl && \
+    ${DNF} install -y epel-release && \
+    ${DNF} install -y \
+    rh-ruby26-ruby-devel \
+    rh-ruby26-rubygems \
+    rh-ruby26-rubygem-rake \
+    rpm-build \
+    cmake3
+elif [ $USE_AMZN_EXT -eq 1 ]; then
+    yum update -y && \
+    yum install -y yum-utils && \
+    yum-config-manager --enable epel && \
+    amazon-linux-extras install -y ruby2.6 && \
+    ${DNF} install -y ruby-devel \
+           cmake3
+else
+    ${DNF} install -y ruby-devel \
+           rubygems \
+           rpm-build \
+           cmake \
+           libarchive
+fi
+
+if [ $USE_SCL -eq 1 ]; then
+    # For unbound variable error
+    export MANPATH=
+    cd /cmetrics-ruby && source /opt/rh/rh-ruby26/enable && gem install bundler --no-document && bundle install && bundle exec rake
+else
+    cd /cmetrics-ruby && gem install bundler --no-document && bundle install && bundle exec rake
+fi

--- a/ci/yum-test.sh
+++ b/ci/yum-test.sh
@@ -70,5 +70,8 @@ if [ $USE_SCL -eq 1 ]; then
     export MANPATH=
     cd /cmetrics-ruby && source /opt/rh/rh-ruby26/enable && gem install bundler --no-document && bundle install && bundle exec rake
 else
+    if [ $USE_AMZN_EXT -eq 1 ]; then
+        echo 'gem "io-console"' > /cmetrics-ruby/Gemfile.local
+    fi
     cd /cmetrics-ruby && gem install bundler --no-document && bundle install && bundle exec rake
 fi


### PR DESCRIPTION
Add apt and yum based linux platforms testing workflows.
This is because we sometimes met compilation error on CentOS 7/8 and Amazon Linux 2 due to some manner differs.