### PR TITLE
serde: add #concat method

### DIFF
--- a/cmetrics-ruby.gemspec
+++ b/cmetrics-ruby.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 0"
   spec.add_development_dependency "rake-compiler", "~> 1.0"
   spec.add_development_dependency "rake-compiler-dock", "~> 1.0"
+  spec.add_development_dependency "msgpack", "~> 1.4.2"
 
   spec.add_dependency 'mini_portile2', '~> 2.7'
 end

--- a/ext/cmetrics/cmetrics_c.h
+++ b/ext/cmetrics/cmetrics_c.h
@@ -65,5 +65,8 @@ void Init_cmetrics_counter(VALUE rb_mCMetrics);
 void Init_cmetrics_gauge(VALUE rb_mCMetrics);
 void Init_cmetrics_serde(VALUE rb_mCMetrics);
 void Init_cmetrics_untyped(VALUE rb_mCMetrics);
+const struct CMetricsCounter *cmetrics_counter_get_ptr(VALUE rb_mCMetrics);
+const struct CMetricsGauge *cmetrics_gauge_get_ptr(VALUE rb_mCMetrics);
+const struct CMetricsUntyped *cmetrics_untyped_get_ptr(VALUE rb_mCMetrics);
 
 #endif // _CMETRICS_C_H

--- a/ext/cmetrics/cmetrics_counter.c
+++ b/ext/cmetrics/cmetrics_counter.c
@@ -34,6 +34,22 @@ static const rb_data_type_t rb_cmetrics_counter_type = { "cmetrics/counter",
                                                          RUBY_TYPED_FREE_IMMEDIATELY };
 
 
+const struct CMetricsCounter *cmetrics_counter_get_ptr(VALUE self)
+{
+    struct CMetricsCounter *cmetricsCounter = NULL;
+
+    TypedData_Get_Struct(
+            self, struct CMetricsCounter, &rb_cmetrics_counter_type, cmetricsCounter);
+
+    if (NIL_P(self)) {
+        rb_raise(rb_eRuntimeError, "Given CMetrics argument must not be nil");
+    }
+    if (!cmetricsCounter->counter) {
+        rb_raise(rb_eRuntimeError, "Create counter with CMetrics::Counter#create first.");
+    }
+    return cmetricsCounter;
+}
+
 static void
 counter_free(void* ptr)
 {

--- a/ext/cmetrics/cmetrics_gauge.c
+++ b/ext/cmetrics/cmetrics_gauge.c
@@ -34,6 +34,22 @@ static const rb_data_type_t rb_cmetrics_gauge_type = { "cmetrics/gauge",
                                                        RUBY_TYPED_FREE_IMMEDIATELY };
 
 
+const struct CMetricsGauge *cmetrics_gauge_get_ptr(VALUE self)
+{
+    struct CMetricsGauge *cmetricsGauge = NULL;
+
+    TypedData_Get_Struct(
+            self, struct CMetricsGauge, &rb_cmetrics_gauge_type, cmetricsGauge);
+
+    if (NIL_P(self)) {
+        rb_raise(rb_eRuntimeError, "Given CMetrics argument must not be nil");
+    }
+    if (!cmetricsGauge->gauge) {
+        rb_raise(rb_eRuntimeError, "Create gauge with CMetrics::Gauge#create first.");
+    }
+    return cmetricsGauge;
+}
+
 static void
 gauge_free(void* ptr)
 {

--- a/ext/cmetrics/cmetrics_serde.c
+++ b/ext/cmetrics/cmetrics_serde.c
@@ -204,6 +204,8 @@ rb_cmetrics_serde_concat_metric(VALUE self, VALUE rb_data)
     } else {
         rb_raise(rb_eArgError, "nil is not valid value for concatenating");
     }
+
+    return Qnil;
 }
 
 static VALUE

--- a/ext/cmetrics/cmetrics_untyped.c
+++ b/ext/cmetrics/cmetrics_untyped.c
@@ -34,6 +34,22 @@ static const rb_data_type_t rb_cmetrics_untyped_type = { "cmetrics/untyped",
                                                          RUBY_TYPED_FREE_IMMEDIATELY };
 
 
+const struct CMetricsUntyped *cmetrics_untyped_get_ptr(VALUE self)
+{
+    struct CMetricsUntyped *cmetricsUntyped = NULL;
+
+    TypedData_Get_Struct(
+            self, struct CMetricsUntyped, &rb_cmetrics_untyped_type, cmetricsUntyped);
+
+    if (NIL_P(self)) {
+        rb_raise(rb_eRuntimeError, "Given CMetrics argument must not be nil");
+    }
+    if (!cmetricsUntyped->untyped) {
+        rb_raise(rb_eRuntimeError, "Create untyped with CMetrics::Untyped#create first.");
+    }
+    return cmetricsUntyped;
+}
+
 static void
 untyped_free(void* ptr)
 {


### PR DESCRIPTION
feed_each and to_msgpack can handle wired msgpack but to_msgpack
only writes each msgpack blob on demand.

There is no public interface to concatenate wired msgpack in a bunch.