### PR TITLE
Bump up version to v0.3.3

### DIFF
--- a/ext/cmetrics/extconf.rb
+++ b/ext/cmetrics/extconf.rb
@@ -46,7 +46,7 @@ class BuildCMetrics
     @recipe.target = File.join(ROOT, "ports")
     @recipe.files << {
       url: "https://codeload.github.com/calyptia/cmetrics/tar.gz/v#{version}",
-      sha256sum: "c0b239fad559852c0c088879697c26e00ba243cfb1c4b8bca6246d1f50932842e",
+      sha256sum: "9f0bdc64268ddaa0906ebd8ae4e5cb396f9730695e5697514fc3a5287fe41826",
     }
   end
 
@@ -70,7 +70,7 @@ class BuildCMetrics
   end
 end
 
-cmetrics = BuildCMetrics.new("0.3.0", cmake_command: determine_preferred_command("cmake3", "cmake"))
+cmetrics = BuildCMetrics.new("0.3.3", cmake_command: determine_preferred_command("cmake3", "cmake"))
 cmetrics.build
 
 libdir = RbConfig::CONFIG["libdir"]

--- a/lib/cmetrics/version.rb
+++ b/lib/cmetrics/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CMetrics
-  VERSION = "0.3.0"
+  VERSION = "0.3.3"
 end


### PR DESCRIPTION
* Use cmetrics *library* v0.3.3
* Bump up cmetrics-ruby that is cmetrics library binding to v0.3.3

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>