### PR TITLE
Fix build error on Windows with HEAD

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,16 @@ jobs:
         ruby-version: '3.0'
     - name: Run the default task
       run: |
+        # Windows's cmake can't handle long path over 260 characters.
+        # It could not be avoided by CMAKE_OBJECT_PATH_MAX configuration.
+        # To avoid this, it copy the repository to short directry name.
+        Copy-Item -Path $PWD.Path -Destination /cm -Recurse
+        cd /cm
+
         gem install bundler -v 2.2.26
         ridk exec bundle install
         ridk exec bundle exec rake
+
+        # Clean up
+        cd /
+        Remove-Item -Path /cm -Recurse -Force

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -9,15 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         label:
-          - CentOS 7 x86_64
           - RockyLinux OS 8 x86_64
           - RockyLinux OS 9 x86_64
           - Fedora 37 x86_64
           - AmazonLinux 2 x86_64
         include:
-          - label: CentOS 7 x86_64
-            test-docker-image: centos:7
-            test-script: ci/yum-test.sh
           - label: RockyLinux OS 8 x86_64
             test-docker-image: rockylinux:8
             test-script: ci/yum-test.sh

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -9,11 +9,15 @@ jobs:
       fail-fast: false
       matrix:
         label:
+          - CentOS 7 x86_64
           - RockyLinux OS 8 x86_64
           - RockyLinux OS 9 x86_64
           - Fedora 37 x86_64
           - AmazonLinux 2 x86_64
         include:
+          - label: CentOS 7 x86_64
+            test-docker-image: centos:7
+            test-script: ci/yum-test.sh
           - label: RockyLinux OS 8 x86_64
             test-docker-image: rockylinux:8
             test-script: ci/yum-test.sh

--- a/ci/apt-test.sh
+++ b/ci/apt-test.sh
@@ -35,6 +35,6 @@ apt install -V -y lsb-release
 
 apt install -V -y ruby-dev git build-essential pkg-config cmake
 cd /cmetrics-ruby && \
-    gem install bundler --no-document && \
+    gem install bundler -v 2.4.22 --no-document && \
     bundle install && \
     bundle exec rake

--- a/ci/yum-test.sh
+++ b/ci/yum-test.sh
@@ -76,10 +76,10 @@ fi
 if [ $USE_SCL -eq 1 ]; then
     # For unbound variable error
     export MANPATH=
-    cd /cmetrics-ruby && source /opt/rh/rh-ruby26/enable && gem install bundler --no-document && bundle install && bundle exec rake
+    cd /cmetrics-ruby && source /opt/rh/rh-ruby26/enable && gem install bundler -v 2.4.22 --no-document && bundle install && bundle exec rake
 else
     if [ $USE_AMZN_EXT -eq 1 ]; then
         echo 'gem "io-console"' > /cmetrics-ruby/Gemfile.local
     fi
-    cd /cmetrics-ruby && gem install bundler --no-document && bundle install && bundle exec rake
+    cd /cmetrics-ruby && gem install bundler -v 2.4.22 --no-document && bundle install && bundle exec rake
 fi

--- a/ci/yum-test.sh
+++ b/ci/yum-test.sh
@@ -20,6 +20,18 @@ case ${distribution} in
         ;;
     esac
     ;;
+  centos)
+    case ${version} in
+      7)
+        DNF=yum
+        USE_SCL=1
+        ;;
+      8)
+        DNF="dnf --enablerepo=powertools"
+        USE_SCL=1
+        ;;
+    esac
+    ;;
   rocky)
     case ${version} in
       8)

--- a/ci/yum-test.sh
+++ b/ci/yum-test.sh
@@ -20,18 +20,6 @@ case ${distribution} in
         ;;
     esac
     ;;
-  centos)
-    case ${version} in
-      7)
-        DNF=yum
-        USE_SCL=1
-        ;;
-      8)
-        DNF="dnf --enablerepo=powertools"
-        USE_SCL=1
-        ;;
-    esac
-    ;;
   rocky)
     case ${version} in
       8)

--- a/ext/cmetrics/extconf.rb
+++ b/ext/cmetrics/extconf.rb
@@ -45,10 +45,13 @@ class BuildCMetrics
     @cfl_version = cfl_version
     @recipe = MiniPortileCMake.new("cmetrics", @version, **kwargs)
 
-    # To avoid "incompatible pointer type" error
     def @recipe.cmake_compile_flags
       flags = super
+      # To avoid "incompatible pointer type" error
       flags << "-DCMAKE_C_FLAGS='-Wno-incompatible-pointer-types'"
+
+      # To avoid "Compatibility with CMake < 3.5 has been removed from CMake." error with CMake 4.0
+       flags << "-DCMAKE_POLICY_VERSION_MINIMUM='3.5'"
     end
 
     @checkpoint = ".#{@recipe.name}-#{@recipe.version}.installed"

--- a/ext/cmetrics/extconf.rb
+++ b/ext/cmetrics/extconf.rb
@@ -44,6 +44,13 @@ class BuildCMetrics
     @fluent_otel_version = fluent_otel_version
     @cfl_version = cfl_version
     @recipe = MiniPortileCMake.new("cmetrics", @version, **kwargs)
+
+    # To avoid "incompatible pointer type" error
+    def @recipe.cmake_compile_flags
+      flags = super
+      flags << "-DCMAKE_C_FLAGS='-Wno-incompatible-pointer-types'"
+    end
+
     @checkpoint = ".#{@recipe.name}-#{@recipe.version}.installed"
     @recipe.target = File.join(ROOT, "ports")
     @recipe.files << {


### PR DESCRIPTION
When I built the master branch code on Windows,
I got the following error.

```
PS C:\src\calyptia-cmetrics-ruby> ridk exec rake
mkdir -p tmp/x64-mingw-ucrt/cmetrics/3.4.1
cd tmp/x64-mingw-ucrt/cmetrics/3.4.1
C:/Ruby34-x64/bin/ruby.exe -I. ../../../../ext/cmetrics/extconf.rb
checking for whether cmake3 or cmake is usable... cmake
Downloading v0.5.9 (100%)

... (snip) ...

[ 88%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_decode_msgpack.c.obj
bash.exe: warning: could not find /tmp, please create!
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_decode_msgpack.c: In function 'unpack_basic_type_meta':
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_decode_msgpack.c:998:21: error: assignment to 'struct cmt_counter *' from incompatible pointer type 'struct counter *' [-Wincompatible-pointer-types]
  998 |             counter = (struct counter *) decode_context->map->parent;
      |                     ^
make[2]: *** [src/CMakeFiles/cmetrics-static.dir/build.make:410: src/CMakeFiles/cmetrics-static.dir/cmt_decode_msgpack.c.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:435: src/CMakeFiles/cmetrics-static.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
----- end of file -----
*** ../../../../ext/cmetrics/extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include=${opt-dir}/include
        --without-opt-include
        --with-opt-lib=${opt-dir}/lib
        --without-opt-lib
        --with-make-prog
        --without-make-prog
        --srcdir=../../../../ext/cmetrics
        --curdir
        --ruby=C:/Ruby34-x64/bin/$(RUBY_BASE_NAME)
C:/Ruby34-x64/lib/ruby/gems/3.4.0/gems/mini_portile2-2.8.8/lib/mini_portile2/mini_portile.rb:627:in 'block in MiniPortile#execute': Failed to complete compile task (RuntimeError)
        from C:/Ruby34-x64/lib/ruby/gems/3.4.0/gems/mini_portile2-2.8.8/lib/mini_portile2/mini_portile.rb:593:in 'Dir.chdir'
        from C:/Ruby34-x64/lib/ruby/gems/3.4.0/gems/mini_portile2-2.8.8/lib/mini_portile2/mini_portile.rb:593:in 'MiniPortile#execute'
        from C:/Ruby34-x64/lib/ruby/gems/3.4.0/gems/mini_portile2-2.8.8/lib/mini_portile2/mini_portile.rb:194:in 'MiniPortile#compile'
        from ../../../../ext/cmetrics/extconf.rb:121:in 'BuildCMetrics#build'
        from ../../../../ext/cmetrics/extconf.rb:145:in '<main>'
rake aborted!
Command failed with status (1): [C:/Ruby34-x64/bin/ruby.exe -I. ../../../../ext/cmetrics/extconf.rb]

Tasks: TOP => default => compile => compile:x64-mingw-ucrt => compile:cmetrics:x64-mingw-ucrt => copy:cmetrics:x64-mingw-ucrt:3.4.1 => tmp/x64-mingw-ucrt/cmetrics/3.4.1/cmetrics.so => tmp/x64-mingw-ucrt/cmetrics/3.4.1/Makefile
(See full trace by running task with --trace)
```

This patch will avoid above compile error on Windows.
