### PR TITLE
ci: use centos:7 on ghcr.io/fluent/flunt-package-centos-7

### DIFF
--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -16,7 +16,7 @@ jobs:
           - AmazonLinux 2 x86_64
         include:
           - label: CentOS 7 x86_64
-            test-docker-image: centos:7
+            test-docker-image: ghcr.io/fluent/fluent-package-centos-7
             test-script: ci/yum-test.sh
           - label: RockyLinux OS 8 x86_64
             test-docker-image: rockylinux:8


### PR DESCRIPTION
It is a snapshot which points vault.centos.org.

  [root@19f7c564c720 /]# cat /etc/redhat-release
  CentOS Linux release 7.9.2009 (Core)